### PR TITLE
Updated the form's bug and validator's messages

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -37,10 +37,12 @@ def read_cities():
 
 class CreateCampaignForm(FlaskForm):
     name = StringField('*שם הקמפיין:',
-                       validators=[DataRequired(), Length(min=3, max=50)], render_kw={"placeholder": "הכנס שם לקמפיין"})
-    start_date = DateField('*תאריך:', validators=[DataRequired()], format='%Y-%m-%d')
-    goal = FloatField('ייעד כספי', render_kw={"placeholder": "הכנס יעד"})
-    city = SelectField('*עיר:', choices=read_cities(), validators=[DataRequired()])
+                       validators=[DataRequired(message='שדה זה הינו שדה חובה'),
+                                   Length(min=3, max=50, message='על שם הקמפיין להכיל בין 3 ל-50 תווים')],
+                       render_kw={"placeholder": "הכנס שם לקמפיין"})
+    start_date = DateField('*תאריך:', validators=[DataRequired(message='שדה זה הינו שדה חובה')], format='%Y-%m-%d')
+    goal = IntegerField('ייעד כספי', validators=[], render_kw={"placeholder": "הכנס יעד", "value": 0})
+    city = SelectField('*עיר:', choices=read_cities(), validators=[DataRequired(message='שדה זה הינו שדה חובה')])
 
     submit = SubmitField('צור קמפיין')
 
@@ -59,46 +61,60 @@ class SearchCampaignForm(FlaskForm):
 
 
 class LoginForm(FlaskForm):
-    username = StringField('שם משתמש:', validators=[DataRequired(), Length(min=2, max=20)],
+    username = StringField('שם משתמש:',
+                           validators=[DataRequired(message='שדה זה הינו שדה חובה'),
+                                       Length(min=2, max=20, message='על שם המשתמש להכיל בין 2 ל-20 תווים')],
                            render_kw={"placeholder": "הזן שם משתמש"})
-    password = PasswordField('סיסמא:', validators=[DataRequired()], render_kw={"placeholder": "הזן סיסמא"})
+    password = PasswordField('סיסמא:', validators=[DataRequired(message='שדה זה הינו שדה חובה')],
+                             render_kw={"placeholder": "הזן סיסמא"})
     remember = BooleanField('זכור אותי')
     submit = SubmitField('התחבר')
 
 
 class AddNeighborhood(FlaskForm):
-    neighborhood_id = SelectField("בחר שכונה", coerce=int, validators=[DataRequired()], choices=[])
+    neighborhood_id = SelectField("בחר שכונה", coerce=int, validators=[DataRequired(message='שדה זה הינו שדה חובה')],
+                                  choices=[])
     number_of_teams = IntegerField("מספר צוותים", validators=[NumberRange(min=1)])
     submit = SubmitField('הוסף שכונה')
 
 
 class DonationForm(FlaskForm):
-    amount = FloatField('סכום לתרומה:', validators=[DataRequired(), NumberRange(min=5, message='*אין להזין תרומות '
-                                                                                               'מתחת ל-5 ש"ח')])
-    payment_type = RadioField('אמצעי תשלום', validators=[DataRequired(message="*סוג התשלום הינו שדה חובה")],
+    amount = FloatField('סכום לתרומה:', validators=[DataRequired(message='שדה זה הינו שדה חובה'),
+                                                    NumberRange(min=5, message='אין להזין תרומות '
+                                                                               'מתחת ל-5 ש"ח')])
+    payment_type = RadioField('אמצעי תשלום', validators=[DataRequired(message="סוג התשלום הינו שדה חובה")],
                               choices=[("PayPal", 'PayPal'), ("Cash", 'מזומן'), ("bit", 'bit')], default="Cash")
     submit = SubmitField('המשך')
 
 
 class BitForm(FlaskForm):
     account_num = StringField("מספר איש קשר להעברה:", render_kw={"value": BIT_ACCOUNT_NUM, "disabled": ""})
-    transaction_id = StringField('מספר אישור:', validators=[DataRequired(), Regexp('^[0-9]{4}-[0-9]{4}-[0-9]{5}$',
-                                                                                   message='אנא הזן את מספר האישור '
-                                                                                           'לפי ההנחיה')])
+    transaction_id = StringField('מספר אישור:', validators=[DataRequired(message='שדה זה הינו שדה חובה'),
+                                                            Regexp('^[0-9]{4}-[0-9]{4}-[0-9]{5}$',
+                                                                   message='אנא הזן את מספר האישור '
+                                                                           'לפי ההנחיה')])
     submit = SubmitField('המשך')
 
 
 class PaperInvoiceForm(FlaskForm):
     reference_id = StringField('מספר קבלה:',
-                               validators=[DataRequired(), Length(min=INVOICE_REF_LENGTH, max=INVOICE_REF_LENGTH,
-                                                                  message=f'אנא הזן את מספר הקבלה הכולל {INVOICE_REF_LENGTH} ספרות במלואו')])
+                               validators=[DataRequired(message='שדה זה הינו שדה חובה'),
+                                           Length(min=INVOICE_REF_LENGTH, max=INVOICE_REF_LENGTH,
+                                                  message=f'אנא הזן את מספר הקבלה הכולל {INVOICE_REF_LENGTH} ספרות '
+                                                          f'במלואו')])
     submit_p = SubmitField('סיים תרומה')
 
 
 class DigitalInvoiceForm(FlaskForm):
-    mail_address = StringField('כתובת מייל:', validators=[DataRequired(), Email()])
-    donor_id = StringField('ת.ז/ח.פ התורם:', validators=[DataRequired(), Length(min=9, max=9,
-                                                                                message='אנא הזן מספר ת.ז/ח.פ בעל 9 ספרות, כולל ספרת הביקורת')])
-    donor_name = StringField('שם התורם:', validators=[DataRequired()])
+    mail_address = StringField('כתובת מייל:', validators=[DataRequired(message='שדה זה הינו שדה חובה'),
+                                                          Email(message='אנא הזן כתובת מייל תקינה')])
+    donor_id = StringField('ת.ז/ח.פ התורם:',
+                           validators=[DataRequired(message='שדה זה הינו שדה חובה'), Length(min=9, max=9,
+                                                                                            message='אנא הזן מספר '
+                                                                                                    'ת.ז/ח.פ בעל 9 '
+                                                                                                    'ספרות, '
+                                                                                                    'כולל ספרת '
+                                                                                                    'הביקורת')])
+    donor_name = StringField('שם התורם:', validators=[DataRequired(message='שדה זה הינו שדה חובה')])
 
     submit_d = SubmitField('סיים תרומה')

--- a/templates/create_campaign.html
+++ b/templates/create_campaign.html
@@ -4,7 +4,7 @@
     <h3>יצירת קמפיין</h3>
 </div>
 <main id="main_layout" class="unified_layout">
-    <form class="report_form" method="POST" action="{{ url_for('create_campaign') }}">
+    <form class="report_form" method="POST">
         {{ form.hidden_tag() }}
         <div class="form-group">
             {{ form.name.label(class="form-control-label") }}

--- a/templates/create_report.html
+++ b/templates/create_report.html
@@ -4,7 +4,7 @@
     <h3>יצירת דיווח</h3>
 </div>
 <main id="main_layout" class="unified_layout">
-    <form class="report_form" method="GET" action="{{ url_for('reports') }}">
+    <form class="report_form" method="GET">
         <div class="form-group">
             <label for="inputAddress">*עיר:</label>
             <input type="text" class="form-control" id="inputAddress" placeholder="הכנס עיר" name="city" maxlength="25"

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 {% block content %}
 <main id="main_layout" class="unified_layout login_layout" style="text-align: right">
-    <form method="POST" action="">
+    <form method="POST">
         {{ form.hidden_tag() }}
         <img src="{{ url_for('static', filename='app_logo.png') }}" class="app_logo" alt="הקש ותרום">
         <legend class="mb-4 center_text font_rub">התחברות</legend>

--- a/templates/manage_campaign.html
+++ b/templates/manage_campaign.html
@@ -7,7 +7,7 @@
     <section class="boxes_container flex_me">
       <section class="box search manage_search">
         <h3 class=center_text> <u>חיפוש קמפייניים:</u></h3>
-        <form method="POST" action="{{ url_for('manage_campaign') }}">
+        <form method="POST">
           {{ form.hidden_tag() }}
           <div class="form-row">
             <div class="col-md-8 mb-3">


### PR DESCRIPTION
fix #48 
fix #78 

All forms are working with validation as intended now. 

About Errors in heb/en: 
MOST of the errors are fixed and in Hebrew.
The only ones who are not are defaulted one, for example: when an integer field is left empty or gets a string, the message shown is as follows: "Not a valid integer value". 
or: the frontend "required" ones (which I'm not sure can be edited, since they're automatically applied by the wtforms dataRequired)

While it might be possible to fix it (https://wtforms.readthedocs.io/en/stable/i18n/) I'm not sure it's worth the hassle.

