### PR TITLE
Filtered team reports and add admin filter option

### DIFF
--- a/app.py
+++ b/app.py
@@ -506,7 +506,17 @@ def reports():
     # Start with an empty query
     reports_query = Report.query
 
+    # If the user is a team, show only reports from the team's campaign
+    if not current_user.is_admin:
+        reports_query = reports_query.join(Report.team, aliased=True).filter_by(
+            campaign_id=current_user.team.campaign_id)
+
     if form.submit():
+        # If the user is an admin and he chose a specific campaign to show
+        if form.campaign.data:
+            reports_query = reports_query.join(Report.team, aliased=True).filter_by(
+                campaign_id=form.campaign.data)
+
         # If the user added category, add it to the query
         if form.category.data:
             reports_query = reports_query.filter(Report.category == form.category.data)

--- a/forms.py
+++ b/forms.py
@@ -117,6 +117,9 @@ class RespondReportForm(FlaskForm):
 
 
 class SearchReportForm(FlaskForm):
+    campaign = SelectField('קמפיין:',
+                           choices=([("", "")] + [(campaign.id, campaign.name) for campaign in Campaign.query.all()]),
+                           default="")
     category = SelectField('סוג הדיווח:',
                            choices=([(value, value) for value in search_report_categories]),
                            default="")

--- a/templates/reports.html
+++ b/templates/reports.html
@@ -25,6 +25,14 @@
                 <h3 class=center_text><u>חפש דיווחים:</u></h3>
                 <form method="POST">
                     {{ form.hidden_tag() }}
+                    {% if current_user.is_admin %}
+                        <div class="form-row">
+                            <div class="col-md-8 mb-3">
+                                {{ form.campaign.label() }}
+                                {{ form.campaign(class="form-control") }}
+                            </div>
+                        </div>
+                    {% endif %}
                     <div class="form-row">
                         <div class="col-md-8 mb-3">
                             {{ form.category.label() }}


### PR DESCRIPTION
fix #138   and more

include:
- Teams will only see reports from their campaign.
- Admins now have a new filter feature for reports: filter by campaign.